### PR TITLE
Move webpack and typescript to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-plotly.js": "^2.5.1",
-    "react-select": "^4.3.0",
+    "react-select": "^4.3.0"
+  },
+  "devDependencies": {
     "ts-loader": "^8.1.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.3.0-dev.20210331",
     "webpack": "^5.28.0",
-    "webpack-cli": "^4.6.0"
-  },
-  "devDependencies": {
+    "webpack-cli": "^4.6.0",
     "webpack-bundle-analyzer": "^4.4.1",
     "webpack-dev-server": "^3.11.2"
   },


### PR DESCRIPTION
Many of these dependencies are not needed at runtime and can be instead by moved to devDependencies.

Take a look at the install size here https://packagephobia.com/result?p=sql.js-httpvfs@0.8.6