### PR TITLE
add cachebusting

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ const result = await worker.db.exec(`select * from table where id = ?`, [123]);
 
 ```
 
+## Cachebusting
+
+Alongside the `url` or `urlPrefix`, config can take an optional `cacheBust` property whose value will be appended as a query parameter to URLs. If you set it to a random value when you update the database you can avoid caching-related database corruption.
+
+If using a remote config (`from: 'jsonconfig'`), don't forget to cachebust that too.
+
 ## Debugging data fetching
 
 If your query is fetching a lot of data and you're not sure why, try this:

--- a/src/sqlite.worker.ts
+++ b/src/sqlite.worker.ts
@@ -59,6 +59,7 @@ export type SplitFileConfigPure = {
 };
 export type SplitFileConfigInner = {
   requestChunkSize: number;
+  cacheBust?: string;
 } & (
   | {
       serverMode: "chunked";
@@ -145,20 +146,21 @@ const mod = {
         config.serverMode === "chunked" ? config.urlPrefix : config.url;
       console.log("constructing url database", id);
       let rangeMapper: RangeMapper;
+      let suffix = config.cacheBust ? "?cb=" + config.cacheBust : "";
       if (config.serverMode == "chunked") {
         rangeMapper = (from: number, to: number) => {
           const serverChunkId = (from / config.serverChunkSize) | 0;
           const serverFrom = from % config.serverChunkSize;
           const serverTo = serverFrom + (to - from);
           return {
-            url: config.urlPrefix + String(serverChunkId).padStart(3, "0"),
+            url: config.urlPrefix + String(serverChunkId).padStart(3, "0") + suffix,
             fromByte: serverFrom,
             toByte: serverTo,
           };
         };
       } else {
         rangeMapper = (fromByte, toByte) => ({
-          url: config.url,
+          url: config.url + suffix,
           fromByte,
           toByte,
         });


### PR DESCRIPTION
If the database gets updated while your browser has the old one cached, it can end up looking corrupted.

This doesn't help if it's updated _while the page is loaded_, but at least it will work after refreshing without requiring manual cache eviction.

(If you don't want to support this, no worries. Figured I'd PR it since it was already written.)