### PR TITLE
fix: suffixLength not being utilised when padding serverChunkId

### DIFF
--- a/src/sqlite.worker.ts
+++ b/src/sqlite.worker.ts
@@ -153,7 +153,7 @@ const mod = {
           const serverFrom = from % config.serverChunkSize;
           const serverTo = serverFrom + (to - from);
           return {
-            url: config.urlPrefix + String(serverChunkId).padStart(3, "0") + suffix,
+            url: config.urlPrefix + String(serverChunkId).padStart(config.suffixLength, "0") + suffix,
             fromByte: serverFrom,
             toByte: serverTo,
           };


### PR DESCRIPTION
This fixes errors when trying to use a suffixLength other than 3, which you may need to do if you have a file size limit and also a very large DB.