### PR TITLE
add suffix length field to config type definition

### DIFF
--- a/src/sqlite.worker.ts
+++ b/src/sqlite.worker.ts
@@ -66,6 +66,7 @@ export type SplitFileConfigInner = {
       urlPrefix: string;
       serverChunkSize: number;
       databaseLengthBytes: number;
+      suffixLength: number;
     }
   | {
       serverMode: "full";


### PR DESCRIPTION
Seems like this is defined in the shell scripts and is used by the code, but this field doesn't exist within the type definition, causing TypeScript to complain.