### PR TITLE
do not parse `sql-wasm.js`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
   // mode:,
   devtool: "source-map",
   module: {
+    noParse: /sql-wasm\.js/,
     rules: [
       {
         test: /\.tsx?$/,


### PR DESCRIPTION
Do not parse `sql-wasm.js` which does not contain imports, but has conditionals of the type `if (typeof module === 'undefined')` which can be broken by webpack

#46 
https://github.com/sql-js/sql.js/issues/406