### PR TITLE
enable `LEGACY_RUNTIME` for recent emscripten

### DIFF
--- a/sql.js/Makefile
+++ b/sql.js/Makefile
@@ -39,7 +39,8 @@ EMFLAGS = \
 	-s EXTRA_EXPORTED_RUNTIME_METHODS=@src/exported_runtime_methods.json \
 	-s SINGLE_FILE=0 \
 	-s NODEJS_CATCH_EXIT=0 \
-	-s NODEJS_CATCH_REJECTION=0
+	-s NODEJS_CATCH_REJECTION=0 \
+	-s LEGACY_RUNTIME=1
 
 #	-s ASYNCIFY=1 \
 #	-s ASYNCIFY_IMPORTS='["sqlite3VdbeExec"]'


### PR DESCRIPTION
Recent versions of emscripten require `LEGACY_RUNTIME` in order to use `allocateUTF8`

https://github.com/emscripten-core/emscripten/issues/9786