### PR TITLE
Optional url for HEAD method

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The full code of this example is in [example/](./example/).
 
 ## Compiling
 
-To compile this project (only needed if you want to modify the library itself), make sure you have emscripten, then first compile sql.js, then sql.js-httpvfs:
+To compile this project (only needed if you want to modify the library itself), make sure you have emscripten (min. 3.1.0), then first compile sql.js, then sql.js-httpvfs:
 
 ```
 cd sql.js

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "webpack serve --mode=development",
-    "build": "webpack build --mode=production"
+    "build": "webpack build --mode=production",
+    "build-sql": "cd sql.js && yarn build && cd .. && webpack build --mode=production"
   },
   "dependencies": {
     "comlink": "^4.3.0"

--- a/sql.js/Makefile
+++ b/sql.js/Makefile
@@ -39,8 +39,7 @@ EMFLAGS = \
 	-s EXTRA_EXPORTED_RUNTIME_METHODS=@src/exported_runtime_methods.json \
 	-s SINGLE_FILE=0 \
 	-s NODEJS_CATCH_EXIT=0 \
-	-s NODEJS_CATCH_REJECTION=0 \
-	-s LEGACY_RUNTIME=1
+	-s NODEJS_CATCH_REJECTION=0
 
 #	-s ASYNCIFY=1 \
 #	-s ASYNCIFY_IMPORTS='["sqlite3VdbeExec"]'

--- a/src/lazyFile.ts
+++ b/src/lazyFile.ts
@@ -6,7 +6,7 @@
 export type RangeMapper = (
   fromByte: number,
   toByte: number
-) => { url: string; fromByte: number; toByte: number };
+) => { url: string; headUrl: string; fromByte: number; toByte: number };
 
 export type RequestLimiter = (bytes: number) => void;
 
@@ -169,7 +169,7 @@ export class LazyUint8Array {
   /** verify the server supports range requests and find out file length */
   private checkServer() {
     var xhr = new XMLHttpRequest();
-    const url = this.rangeMapper(0, 0).url;
+    const url = this.rangeMapper(0, 0).headUrl;
     // can't set Accept-Encoding header :( https://stackoverflow.com/questions/41701849/cannot-modify-accept-encoding-with-fetch
     xhr.open("HEAD", url, false);
     // // maybe this will help it not use compression?


### PR DESCRIPTION
Added headUrl as an optional parameter. 
Needed when we want to host the database on object storage and we can't use the same link for both HEAD and GET methods.

I've noticed that the current code base doesn't work with newer versions of enscripten. 
I've used version 3.1.0 in this case.